### PR TITLE
Fix missing 'fi' statement at the end of snack.sh

### DIFF
--- a/snack.sh
+++ b/snack.sh
@@ -196,3 +196,4 @@ if [[ -z $CLEAN ]]; then
     applyPatches $ANDROID_BUILD_TOP/.repo/local_manifests/patchlist
 else
     echo Will not repopick or patch--run without -w to pick and patch
+fi


### PR DESCRIPTION
This caused the script to fail to apply repopicks and patches to the repo.